### PR TITLE
Add optional -r flag for test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ The tester is written in LDPL. To compile and run it you should run
 
 preferably with a stable version of LDPL.
 
-To use a development version of LDPL, set the `LDPLBIN` environment 
-variable: 
-
-`env LDPLBIN=/path/to/dev/ldpl sh compileAndRunTester.sh`
-
 ## How to run the tester
 Run `$ ./tester`.
+
+## Using a custom runner
+By default the tester will compile and run each test with `ldpl`, but you can define your own "compile and run" process by providing a runner script with the `-r=` flag:
+
+    ldpl tester.ldpl -o=tester
+    ./tester -r=my-ldpl.sh
+
+This would execute the `my-ldpl.sh` program once for each test file, passing the test file as the first argument. In your runner script you could, for example, build and run each test file with a development version of LDPL. Or a different compiler/interpreter entirely.
+

--- a/compileAndRunTester.sh
+++ b/compileAndRunTester.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 echo "Compiling the Tester..."
-${LDPLBIN:-ldpl} tester.ldpl -o=tester
+ldpl tester.ldpl -o=tester
 ./tester
 rm tester

--- a/tester.ldpl
+++ b/tester.ldpl
@@ -13,6 +13,7 @@ testCount is number
 i is number
 failCount is number
 passCount is number
+testRunner is text
 
 PROCEDURE:
 # ------------------------------------------------------------
@@ -58,6 +59,12 @@ display crlf " \033[90m+----------------------------------------+" crlf
 display " \033[90m| \033[92mLDPL Programming Language\033[96m Test Battery\033[90m |\033[0m" crlf
 display " \033[90m+----------------------------------------+\033[0m" crlf crlf
 
+# optional test runner
+get index of "-r=" from argv:0 in i
+if i is greater than or equal to 0 then
+    replace "-r=" from argv:0 with "" in testRunner
+end if
+
 # Count tests
 store 0 in testCount
 store 0 in i
@@ -74,13 +81,20 @@ store 0 in i
 while i is less than testCount do
     store tests:i in testName
     display "\033[33mTesting '" testName ".ldpl'\033[0m" crlf
-    in command join "cd tests && ldpl " testName ".ldpl -o=" testName " > /dev/null"
-    call execute-command
-    in command join "cd tests && ./" testName " > " testName ".test"
-    call execute-command
+    if testRunner is equal to "" then
+        in command join "cd tests && ldpl " testName ".ldpl -o=" testName " > /dev/null"
+        call execute-command
+        in command join "cd tests && ./" testName " > " testName ".test"
+        call execute-command
+    else
+        in command join "cd tests && " testRunner " " testName ".ldpl > " testName ".test"
+        call execute-command
+    end if
     call compare-results
-    in command join "cd tests && rm " testName
-    call execute-command
+    if testRunner is equal to "" then
+      in command join "cd tests && rm " testName
+      call execute-command
+    end if
     display crlf
     add 1 and i in i
 repeat


### PR DESCRIPTION
This allows you to run the tests using a different version of LDPL:

    $ ldpl tester.ldpl -r=tester
    $ ./tester -r=dino

This runs each test with `dino testfile.ldpl > testfile.test` 